### PR TITLE
Return the promises of relation.js

### DIFF
--- a/packages/push/src/relation.js
+++ b/packages/push/src/relation.js
@@ -7,11 +7,11 @@ export default class Relation {
   create(attributes) {
     let resource = new this.resource(attributes);
 
-    this.client.post(this.endpoint, resource);
+    return this.client.post(this.endpoint, resource);
   }
 
   delete(identifier) {
-    this.client.delete(`${this.endpoint}/${identifier}`);
+    return this.client.delete(`${this.endpoint}/${identifier}`);
   }
 
   get client() {


### PR DESCRIPTION
In JavaScript, promises must be returned or 1) they can't be used with `Promise.all()` and 2) the program could terminate before they are executed.